### PR TITLE
Updated AAP on OCP as lightspeed is disabled by default

### DIFF
--- a/documentation/modules/ROOT/pages/12-platform-aap_on_openshift.adoc
+++ b/documentation/modules/ROOT/pages/12-platform-aap_on_openshift.adoc
@@ -82,7 +82,7 @@ Next to the _Details_ tab click on **YAML**. This will show you the current YAML
   route_tls_termination_mechanism: Edge
 ----
 
-This `spec` definition shows us that the `controller`, `eda`, `hub`, and `lightspeed` components are enabled (`disabled: false`) and some customizations made to the `hub` component specifically.
+This `spec` definition shows us that the `controller`, `eda`, and `hub` components are enabled (`disabled: false`) and some customizations made to the `hub` component specifically.
 
 === 2.2: Resources managed by the CRDs
 


### PR DESCRIPTION
Updated AAP on OCP as lightspeed is disabled by default to resolve #43 