### PR TITLE
Update python devel package version to 3.12

### DIFF
--- a/documentation/modules/ROOT/pages/25-content-config-as-code.adoc
+++ b/documentation/modules/ROOT/pages/25-content-config-as-code.adoc
@@ -91,7 +91,7 @@ dependencies:
   system:
     - gcc [platform:rpm]
     - systemd-devel [platform:rpm]
-    - python3.11-devel [platform:rpm]
+    - python3.12-devel [platform:rpm]
   galaxy:
     collections:
       - name: ansible.platform


### PR DESCRIPTION
The ee-minimal-rhel9 container image updated to using python3.12 as of the 2.0 release of the image.